### PR TITLE
Update rspec version to 3.5

### DIFF
--- a/rsbe-client.gemspec
+++ b/rsbe-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.0.0"
+  spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "rspec-its", "~> 1.0.1"
   spec.add_development_dependency "vcr", "~> 2.9.3"
   spec.add_development_dependency "webmock", "~> 1.18.0"


### PR DESCRIPTION
Update rspec version to 3.5 to compensate for
   `NoMethodError: undefined method 'last_comment'` issue caused by an
    incompatibility between rake and rspec.

For details on this issue, please refer to [this page](http://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11)
