### PR TITLE
Update activesupport version

### DIFF
--- a/lib/rsbe/client/version.rb
+++ b/lib/rsbe/client/version.rb
@@ -1,5 +1,5 @@
 module Rsbe
   module Client
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end

--- a/rsbe-client.gemspec
+++ b/rsbe-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "rspec-its", "~> 1.0.1"
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10.1"
 
   spec.add_dependency "faraday", "~> 0.9.0"
-  spec.add_dependency "activesupport", "~> 4.1.6"
+  spec.add_dependency "activesupport", "~> 4.2.11"
 end


### PR DESCRIPTION
Update active support version to get rid of `json` gem warnings.
